### PR TITLE
Fix bug in 3x3x3 3d Tic-Tac-Toe

### DIFF
--- a/Common/res/lud/board/space/line/3D Tic-Tac-Toe.lud
+++ b/Common/res/lud/board/space/line/3D Tic-Tac-Toe.lud
@@ -25,7 +25,7 @@
         (start (place "Dot0" <Board:dot0>)) // Places neutral dots to separate the four levels of the board.
         (play (move Add (to (sites Empty))))
         (end {
-            (if (is Line 4) (result Mover Win))
+            (if (is Line <Board:size>) (result Mover Win))
             (if "Line3D" (result Mover Win))
         })
     )


### PR DESCRIPTION
At the moment the "flat" 3 in a row is not counted as win.