### PR TITLE
Slighly inconsistent syntax in a handfull of games

### DIFF
--- a/Common/res/lud/board/race/reach/Center.lud
+++ b/Common/res/lud/board/race/reach/Center.lud
@@ -50,7 +50,7 @@
     }
 )
 
-(option "Pie rule" <Pie> args:{ <pie> <direction>}
+(option "Pie rule" <Pie> args:{ <pie> }
     {
     (item "Off" <> "The pie rule is currently not in force.")*
     (item "On" <(meta (swap))> "The pie rule is currently in force.")

--- a/Common/res/lud/board/space/territory/Bug.lud
+++ b/Common/res/lud/board/space/territory/Bug.lud
@@ -304,7 +304,7 @@
 
 //---------------
 
-(option "Board" <Board> args:{ <type> <graphics> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Hex3" <(hex Hexagon 3)> "3 Hexagon")**
     (item "Hex 343434" <(hex Limping 3)> "343434 Hexagon")

--- a/Common/res/lud/experimental/Mutant Y^3.lud
+++ b/Common/res/lud/experimental/Mutant Y^3.lud
@@ -240,7 +240,7 @@
 //-------------------------------------------------
 // Options
 
-(option "Protocol" <Protocol> args:{<type> <piece>}
+(option "Protocol" <Protocol> args:{ <type> }
     {
     (item "Alternating" <("AlternatingMoves")> "Turns alternate")
     (item "Turns (FE)*" <("FriendEnemyMoves")> "Turns follow (FE)* protocol: Each player places a Friend then places an Enemy.")

--- a/Common/res/lud/experimental/Parry.lud
+++ b/Common/res/lud/experimental/Parry.lud
@@ -209,7 +209,7 @@
         //      )> 
     //     <All> <Thin> "Board & size: Orthogonal 3")
     //    (item "Square 4 ortho (16)"  <(square 4)>          <Orthogonal> <Hidden>  "Board & size: Orthogonal 5") 
-    (item "Equiversi 2-4 (18)"   <(tri {2 4 2 4 2})>    <Orthogonal> <Hidden>  "Board & size: //Equiversi Hexhex with edges alternating 2 and 4")
+    (item "Equiversi 2-4 (18)"   <(tri {2 4 2 4 2})>    <Orthogonal> <Hidden>  "Board & size: Equiversi Hexhex with edges alternating 2 and 4")
     (item "Hex 3 (19)"           <(tri Hexagon 3)>     <Orthogonal> <Hidden>  "Board & size: Hexhex 3")
     (item "Square 5 ortho (25)" <(square 5)>          <Orthogonal> <Hidden>  "Board & size: Orthogonal 5") 
     (item "Square 4 omni (25)" 

--- a/Common/res/lud/experimental/graph_theory/LastEdge.lud
+++ b/Common/res/lud/experimental/graph_theory/LastEdge.lud
@@ -21,7 +21,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <

--- a/Common/res/lud/experimental/graph_theory/Nein Ari.lud
+++ b/Common/res/lud/experimental/graph_theory/Nein Ari.lud
@@ -22,7 +22,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <

--- a/Common/res/lud/experimental/graph_theory/Oriath.lud
+++ b/Common/res/lud/experimental/graph_theory/Oriath.lud
@@ -18,7 +18,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <

--- a/Common/res/lud/math/graph/Hamiltonian Maze.lud
+++ b/Common/res/lud/math/graph/Hamiltonian Maze.lud
@@ -29,7 +29,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <

--- a/Common/res/lud/math/graph/MaxMatch.lud
+++ b/Common/res/lud/math/graph/MaxMatch.lud
@@ -33,7 +33,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <

--- a/Common/res/lud/math/graph/Two-Colour.lud
+++ b/Common/res/lud/math/graph/Two-Colour.lud
@@ -28,7 +28,7 @@
 
 //------------------------------------------------------------------------------
 
-(option "Board" <Board> args:{ <type> <start> }
+(option "Board" <Board> args:{ <type> }
     {
     (item "Graph1"    
         <


### PR DESCRIPTION
I encoundered a few oddities which made the instruction-dataset parser crash.

- The first commit removes undefined option categories
- The second removes a double slash which comments out the closing parentheses for an item ludeme. I'm not sure if the intent was to comment out the item or if the slashes where accidental.