### PR TITLE
ConHex Environment Bug Fixed: Central Cell Capture Logic Not Working in ConHex

### DIFF
--- a/Common/res/lud/board/space/connection/ConHex.lud
+++ b/Common/res/lud/board/space/connection/ConHex.lud
@@ -1,5 +1,10 @@
-(define "CellOfLastVertex" 
-    (sites Incident Cell of:Vertex at:(last To)) 
+(define "CellOfLastVertex"
+    (union
+        (sites Incident Cell of:Vertex at:(last To))
+        (if (= (last To) (centrePoint Vertex))
+            (sites Centre)
+        )
+    )
 )
 
 (define "AllHolesOfCell"
@@ -94,7 +99,7 @@
         
         (end {
             (if (is Triggered "Connected" Mover) (result Mover Win))
-            (if (<= 52 (count Moves)) (result Mover Draw))
+            (if (<= 100 (count Moves)) (result Mover Draw))
         }) 
     )
 )


### PR DESCRIPTION
## Description
1. There is an issue in the ConHex game where the central cell is not being captured correctly. According to the rules, the central cell should be captured when a player occupies three of its five surrounding vertices. However, the current implementation does not trigger this behavior, and the central cell remains uncaptured, even when the conditions are met.
2. ConHex does not allow draws as per the official rules [1], but the current implementation includes a draw condition.

## Proposed Solution
1. Modify the "CellOfLastVertex" logic to include the central cell when three vertices are occupied .
2. Change the "Draw" move count from 52 to 100, as there are no draws in ConHex.

Reference:
1. https://nestorgames.com/rulebooks/CONHEX_EN.pdf