### PR TITLE
Fix two stacking-game state bugs (ActionAdd double track-count; level-remove leaves stale slot state)

### DIFF
--- a/Core/src/other/action/move/ActionAdd.java
+++ b/Core/src/other/action/move/ActionAdd.java
@@ -309,9 +309,14 @@ public final class ActionAdd extends BaseAction
 			final int oldCount = cs.count(to, type);
 			cs.setSite(context.state(), to, Constants.UNDEFINED, Constants.UNDEFINED, (game.requiresCount() ? oldCount + count : 1), state, rotation, value,type);
 		}
-		
-		updateTrackIndices(context);
-		
+
+		// For a stacking game, applyStack() already called updateTrackIndices()
+		// above; calling it a second time here double-counts the placement in
+		// OnTrackIndices (a `+= count` accumulator), so only fire it here when
+		// applyStack() was not run.
+		if (!requiresStack)
+			updateTrackIndices(context);
+
 		return this;
 	}
 

--- a/Core/src/other/state/stacking/ContainerGraphStateStacks.java
+++ b/Core/src/other/state/stacking/ContainerGraphStateStacks.java
@@ -1020,6 +1020,13 @@ public class ContainerGraphStateStacks extends ContainerStateStacks
 			}
 			chunkStacksVertex[site].setWhat(state, 0);
 			chunkStacksVertex[site].setWho(state, 0);
+			// Also clear the vacated top slot's state/rotation/value, matching
+			// the level-less remove(...) overload above; otherwise a stale
+			// value survives in the reused chunk slot and is resurrected by a
+			// later state-less addItemGeneric() (the hand-entry push path).
+			chunkStacksVertex[site].setState(state, 0);
+			chunkStacksVertex[site].setRotation(state, 0);
+			chunkStacksVertex[site].setValue(state, 0);
 			chunkStacksVertex[site].decrementSize(state);
 			return componentRemove;
 		}
@@ -1039,6 +1046,11 @@ public class ContainerGraphStateStacks extends ContainerStateStacks
 		}
 		chunkStacksEdge[site].setWhat(state, 0);
 		chunkStacksEdge[site].setWho(state, 0);
+		// Also clear the vacated top slot's state/rotation/value, matching the
+		// level-less remove(...) overload above (see the Vertex branch).
+		chunkStacksEdge[site].setState(state, 0);
+		chunkStacksEdge[site].setRotation(state, 0);
+		chunkStacksEdge[site].setValue(state, 0);
 		chunkStacksEdge[site].decrementSize(state);
 		return componentRemove;
 	}


### PR DESCRIPTION
## Summary

Two independent bugs in the stacking-game state machinery, each fixed to match the correct behavior of a **sibling code path in the same class**. Both were discovered while building a faithful 1:1 TypeScript port of the Core engine and independently confirmed against the running JVM (via `javap`/probe drivers and full random-trial replay). The two code changes are minimal (20 lines) and compile cleanly against the full Ludii classpath (JDK 21).

Branched off `master` at `8ba67089dd` (v1.3.14).

### Fix 1 — `ActionAdd.apply()` double-counts track indices for stacking-game Adds

`Core/src/other/action/move/ActionAdd.java`. When `requiresStack` is true, `apply()` calls `applyStack(context, cs)`, and `applyStack()` ends with `updateTrackIndices(context)` (line 348). `apply()` then **falls through** and calls `updateTrackIndices(context)` a **second time** in its tail (line 313). `OnTrackIndices.add(trackIdx, what, count, index)` is a genuine `+= count` accumulator (`Core/src/other/state/track/OnTrackIndices.java:166-170`), so a stacking-game `Add` really does double the ring-index tally for every track the placement touches — it is not a redundant no-op.

**Fix:** guard the tail call so it only fires when `applyStack()` did not (`if (!requiresStack) updateTrackIndices(context);`).

### Fix 2 — `ContainerGraphStateStacks.remove(state, site, level, type)` leaves stale `state`/`rotation`/`value` in the vacated slot

`Core/src/other/state/stacking/ContainerGraphStateStacks.java`. The level-based `remove(...)` overload shifts every level above the removed one down by one (relocating who/what/state/rotation/value), then clears the now-vacated top slot — but only clears `who` and `what` there, leaving `state`/`rotation`/`value` dirty. The level-**less** sibling `remove(state, site, type)` (a few lines above) correctly clears all five channels. The stale value survives in the reused chunk slot and is resurrected by a later **state-less** `addItemGeneric()` call — the hand-entry push path used by `ActionMoveTopPiece` and `ActionAdd` — which never writes `state`/`rotation`/`value` itself, so the new occupant inherits the previous occupant's residual.

**Fix:** clear `state`/`rotation`/`value` at the vacated slot in both the Vertex and Edge branches, matching the level-less overload.

## How these were found & verified

We built a faithful, byte-for-byte 1:1 port of the Core engine to TypeScript and validated it by replaying Ludii's own recorded `RandomTrial_*` files move-for-move (2,558 trials across the full `Player/res/random_trials` corpus). These two behaviors surfaced as divergences that we traced back to the Java source above, then confirmed were genuinely present in the running engine — not artifacts of the port — via `javap` disassembly and probe drivers replaying the exact trials against the compiled Core classes. Concrete reproductions:

- **Fix 2** reproduces on `board/war/replacement/eliminate/all/Boolik` (a hand-entry piece inherits a captured piece's stale `state` at the same physical stack depth). Full write-up and per-ply JVM evidence available on request.
- **Fix 1** reproduces on any stacking game whose Add touches a track (e.g. `board/war/replacement/eliminate/target/Mini Wars`): the on-track index tally is exactly doubled.

## ⚠️ Behavior change — trial baselines need re-recording

Both fixes change the engine's behavior for the affected stacking games, so the recorded `RandomTrial_*` baselines for those games encode the *old* (buggy) behavior and will need to be regenerated after these land. We are happy to help identify the affected games (those using stacking + tracks for Fix 1, and stacking + level-based removes with a later state-less re-push for Fix 2).

## Additional findings (reported, not patched here)

While porting we catalogued several further discrepancies that we deliberately did **not** turn into code changes in this PR, because each is either subtler than a clear bug, a source-vs-release-binary question, or a representational limit — better decided by the maintainers. Flagging them here for visibility:

- **`FullOwned.remove` bounds check (`Core/src/other/state/owned/FullOwned.java:248`)** — the decrement guard `... && (type == null || i >= locs.size() || locations[idPlayer][i]...siteType().equals(type))` compares the current player's component-index loop variable `i` against `locs.size()`, where `locs` is an *unrelated* list (the removed piece's own component-location list from earlier in the method). When `i >= locs.size()` spuriously holds, the type match is skipped and the level is always decremented, which can leave stale owned-registry entries for *other* pieces at the same site. Looks like a type-confused bounds check but the intended condition isn't obvious from the source — flagging rather than guessing.
- **`Move.java` queued-level-remove order (`Core/src/other/move/Move.java:544-575`)** — the checked-in source applies queued stacking level-removes *descending*, but the behavior we had to match to replay recorded trials is *ascending*. This looks like a source-vs-shipped-binary divergence (either `Core/src` is stale relative to the release these trials were recorded against, or an intermediate change altered the ordering without updating source). Worth a maintainer sanity check against the release binary.
- **`MaxMoves` value-read arity asymmetry (`.../requirement/max/moves/MaxMoves.java`)** — the outer `eval()` sums a candidate's captured value via a per-level container read (3-arg `cs.value(site, level, type)`), while `getReplayCount()`'s recursion sums it via the top-of-stack read (2-arg `cs.value(site, type)`). For a victim whose top level was pushed valueless these disagree. Possibly intended, possibly a bug — flagging as suspect (it is what ranks a particular Fenix hop-chain in the real engine).
- **Plain stacking push drops the mover's value (`ActionMoveTopPiece.java:498`)** — the plain single-piece stacking push uses the value-less `addItemGeneric(state, to, what, who, game, type)` overload, so the new top level always reads value 0, whereas the pop/restore paths in the same class explicitly forward `previousValue*`. Possibly intended stacking semantics — flagging as suspect.
- **`Edge` records at most two faces (`game/util/graph/Edge.java:26-27`, `Graph.findOrAddFace`)** — `setLeft()`/`setRight()` overwrite unconditionally, so a third face claiming an edge silently evicts one of the first two. This is a deliberate planar-graph representational limit rather than an accidental bug, but worth documenting so a future non-planar board generator doesn't rely on `Edge` recording more than two faces.

Full reproduction notes, `@java file:line` citations, and per-ply oracle evidence for all of the above are in the porting project's `UPSTREAM-REPORT.md` (linked from the companion TypeScript-port PR); happy to open separate focused issues for any the maintainers want to pursue.
